### PR TITLE
feat: add stop search by name feature

### DIFF
--- a/src/main/java/pavlo/melnyk/transitanalyzer/controller/api/AnalysisController.java
+++ b/src/main/java/pavlo/melnyk/transitanalyzer/controller/api/AnalysisController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pavlo.melnyk.transitanalyzer.dto.RouteInfoResponseDto;
 import pavlo.melnyk.transitanalyzer.dto.StopDistanceDto;
+import pavlo.melnyk.transitanalyzer.dto.StopSearchDto;
 import pavlo.melnyk.transitanalyzer.service.AnalysisService;
 
 @RestController
@@ -33,5 +34,10 @@ public class AnalysisController {
     public ResponseEntity<List<RouteInfoResponseDto>> getRoutesForStop(
             @PathVariable String stopId) {
         return ResponseEntity.ok(analysisService.findRoutesByStop(stopId));
+    }
+
+    @GetMapping("/stops/search")
+    public ResponseEntity<List<StopSearchDto>> searchStopsByName(@RequestParam String name) {
+        return ResponseEntity.ok(analysisService.searchStopsByName(name));
     }
 }

--- a/src/main/java/pavlo/melnyk/transitanalyzer/dto/StopSearchDto.java
+++ b/src/main/java/pavlo/melnyk/transitanalyzer/dto/StopSearchDto.java
@@ -1,0 +1,13 @@
+package pavlo.melnyk.transitanalyzer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StopSearchDto {
+    private String stopId;
+    private String stopName;
+}

--- a/src/main/java/pavlo/melnyk/transitanalyzer/entity/Stop.java
+++ b/src/main/java/pavlo/melnyk/transitanalyzer/entity/Stop.java
@@ -8,9 +8,11 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.GeoPointField;
+import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 
 @Document(indexName = "stops")
+@Setting(settingPath = "elasticsearch/stop-settings.json")
 @Getter
 @Setter
 @AllArgsConstructor
@@ -18,7 +20,7 @@ public class Stop {
     @Id
     private String stopId;
 
-    @Field(type = FieldType.Text, name = "stop_name")
+    @Field(type = FieldType.Text, name = "stop_name", analyzer = "folding_analyzer")
     private String name;
 
     @GeoPointField

--- a/src/main/java/pavlo/melnyk/transitanalyzer/service/AnalysisService.java
+++ b/src/main/java/pavlo/melnyk/transitanalyzer/service/AnalysisService.java
@@ -5,9 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import pavlo.melnyk.transitanalyzer.dto.RouteInfoResponseDto;
 import pavlo.melnyk.transitanalyzer.dto.StopDistanceDto;
+import pavlo.melnyk.transitanalyzer.dto.StopSearchDto;
 
 public interface AnalysisService {
     Page<StopDistanceDto> findStopsNear(String stopId, double distanceInKm, Pageable pageable);
 
     List<RouteInfoResponseDto> findRoutesByStop(String stopId);
+
+    List<StopSearchDto> searchStopsByName(String name);
 }

--- a/src/main/java/pavlo/melnyk/transitanalyzer/service/AnalysisServiceImpl.java
+++ b/src/main/java/pavlo/melnyk/transitanalyzer/service/AnalysisServiceImpl.java
@@ -19,9 +19,11 @@ import org.springframework.data.elasticsearch.core.query.Criteria;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.elasticsearch.core.query.GeoDistanceOrder;
 import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.stereotype.Service;
 import pavlo.melnyk.transitanalyzer.dto.RouteInfoResponseDto;
 import pavlo.melnyk.transitanalyzer.dto.StopDistanceDto;
+import pavlo.melnyk.transitanalyzer.dto.StopSearchDto;
 import pavlo.melnyk.transitanalyzer.entity.Route;
 import pavlo.melnyk.transitanalyzer.entity.Stop;
 import pavlo.melnyk.transitanalyzer.entity.StopTime;
@@ -82,6 +84,17 @@ public class AnalysisServiceImpl implements AnalysisService {
 
         return StreamSupport.stream(routes.spliterator(), false)
                 .map(this::buildRouteInfoResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<StopSearchDto> searchStopsByName(String name) {
+        Query query = new StringQuery("{\"match_phrase_prefix\":{\"stop_name\":\"" + name + "\"}}");
+        SearchHits<Stop> searchHits = elasticsearchOperations.search(query, Stop.class);
+
+        return searchHits.getSearchHits().stream()
+                .map(hit -> new StopSearchDto(
+                        hit.getContent().getStopId(), hit.getContent().getName()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/resources/elasticsearch/stop-settings.json
+++ b/src/main/resources/elasticsearch/stop-settings.json
@@ -1,0 +1,13 @@
+{
+  "analysis": {
+    "analyzer": {
+      "folding_analyzer": {
+        "tokenizer": "standard",
+        "filter": [
+          "lowercase",
+          "asciifolding"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Added `StopSearchDto` for returning stop id and name
- Extended `AnalysisService` with `searchStopsByName` method
- Implemented full-text search for stops by name using Elasticsearch (match_phrase_prefix)
- Added `GET /api/analysis/stops/search?name=...` endpoint to `AnalysisController`
- Now users can search for stops by partial or full name and get matching stop ids and names